### PR TITLE
Remove unnecessary jitpack repository in Gradle settings

### DIFF
--- a/plugin-build/settings.gradle.kts
+++ b/plugin-build/settings.gradle.kts
@@ -11,7 +11,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven { url = uri("https://jitpack.io") }
     }
 
     versionCatalogs {


### PR DESCRIPTION
## Description
There is no need for including jitpack repository in settings

## Motivation and Context
Cleans Gradle settings a bit
